### PR TITLE
Install twine under appropriate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ test: clean_tests
 
 .PHONY: distribute
 distribute: clean_distribution
-	@ $(PIP_INSTALL) twine
 	@ $(PYTHON) setup.py --quiet sdist bdist_wheel
 
 .PHONY: publish
 publish:
+	@ $(PIP_INSTALL) twine
 	@ twine upload dist/*
 	# @ twine upload --repository testpypi dist/*
 


### PR DESCRIPTION
The twine module is used to upload to PyPI, so it belongs under the
publish target, not the distribute target.